### PR TITLE
build: add test-ci target and use it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,8 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Run unit tests
-        run: make test
-
       - name: Install scrut
         run: curl --proto '=https' --tlsv1.2 -sSf https://facebookincubator.github.io/scrut/install.sh | bash
 
-      - name: Run CLI tests
-        run: make test-cli
+      - name: Run CI test suite
+        run: make test-ci

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,26 @@
 BINARY := jm
 
-.PHONY: all build test test-cli test-cli-live test-all cover vet fmt clean help
+.PHONY: all build binary test test-cli test-cli-live test-all test-ci cover vet fmt clean help
 
 all: build ## Build the binary (default)
 
-build: ## Build the binary
+build: test binary ## Run unit tests and build the binary
+
+binary: ## Build the binary
 	go build -o $(BINARY) .
 
 test: ## Run unit tests
 	go test ./...
 
-test-cli: build ## Run scrut CLI integration tests
+test-cli: binary ## Run scrut CLI integration tests
 	scrut test tests/errors.md tests/flags.md tests/arguments.md tests/help.md
 
-test-cli-live: build ## Run opt-in live CLI integration tests (requires JMAP_TOKEN and JMAP_LIVE_TESTS=1)
+test-cli-live: binary ## Run opt-in live CLI integration tests (requires JMAP_TOKEN and JMAP_LIVE_TESTS=1)
 	scrut test tests/live.md
 
 test-all: test test-cli ## Run all tests (unit + CLI)
+
+test-ci: test-all ## Run CI test suite
 
 cover: ## Run unit tests with coverage
 	go test -coverprofile=coverage.out ./...


### PR DESCRIPTION
## Summary
- make `build` now runs unit tests before compiling by splitting compile-only work into a new `binary` target
- added a dedicated `test-ci` target that runs the deterministic CI suite via `test-all`
- updated the CI workflow to call `make test-ci` so test orchestration is defined in one place

## Testing
- make test-ci