### PR TITLE
fix: use correct GoReleaser binary version in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: goreleaser/goreleaser-action@v6
         with:
-          version: "~> v6"
+          version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Fix `goreleaser-action` version parameter: `~> v6` -> `~> v2`
- The action version (v6) is separate from the GoReleaser binary version (v2.x)
- `~> v6` matched no releases, causing the v0.2.0 release workflow to fail

## Test plan

- [ ] After merge, delete and re-tag v0.2.0 to re-trigger the release workflow