### PR TITLE
Use terminal cell-width calculation for column alignment

### DIFF
--- a/docs/plans/todo/2026-02-17-use-terminal-cell-width-for-column-alignment.md
+++ b/docs/plans/todo/2026-02-17-use-terminal-cell-width-for-column-alignment.md
@@ -1,0 +1,94 @@
+# Use Terminal Cell-Width for Column Alignment
+
+## Context
+
+The text formatter (`internal/output/text.go`) uses `utf8.RuneCountInString` for column width calculation and `fmt.Sprintf("%%-%ds", ...)` for padding. Both operate on Unicode code points (runes), not terminal display columns. This breaks column alignment when sender names or subjects contain characters that occupy more than one terminal cell, such as CJK ideographs (2 columns each), emoji, or zero-width combining marks.
+
+This was identified during PR #14 Copilot review. The rune-based approach was an intentional improvement over byte-based alignment; this is the follow-up to make it fully correct. Tracked as issue #15.
+
+## Approach
+
+Add `github.com/mattn/go-runewidth` as a direct dependency and replace all rune-count-based width calculations and padding with cell-width-aware equivalents.
+
+`go-runewidth` is the de facto standard Go library for terminal column width. It provides `StringWidth` (measure display columns), `FillRight` (pad to display width), and `Truncate` (truncate to display width) -- exactly what we need.
+
+## Changes
+
+### 1. Add dependency
+
+```
+go get github.com/mattn/go-runewidth
+```
+
+### 2. Update `internal/output/text.go`
+
+**Imports**: Replace `unicode/utf8` with `github.com/mattn/go-runewidth`.
+
+**Constants** (lines 15-18): Update comments from "rune count" to "display columns".
+
+**`formatEmailList`** (lines 116-127):
+- Replace `utf8.RuneCountInString(from)` and `utf8.RuneCountInString(subject)` with `runewidth.StringWidth(...)`.
+- Replace the `fmt.Sprintf("%%-%ds", ...)` format string with direct `runewidth.FillRight` calls per column.
+
+Before:
+```go
+fmtStr := fmt.Sprintf("%%s %%-%ds  %%-%ds  %%s\n", maxFrom, maxSubject)
+fmt.Fprintf(w, fmtStr, r.unread, r.from, r.subject, r.date)
+```
+
+After:
+```go
+fmt.Fprintf(w, "%s %s  %s  %s\n", r.unread,
+    runewidth.FillRight(r.from, maxFrom),
+    runewidth.FillRight(r.subject, maxSubject),
+    r.date)
+```
+
+**`formatDryRunResult`** (lines 245-256): Same pattern -- replace `utf8.RuneCountInString` with `runewidth.StringWidth`, replace `fmt.Sprintf` format string with `runewidth.FillRight`.
+
+**`truncate`** (lines 319-327): Replace rune-based logic with `runewidth.StringWidth` for the check and `runewidth.Truncate` for the actual truncation.
+
+Before:
+```go
+func truncate(s string, maxLen int) string {
+    if maxLen < 4 || utf8.RuneCountInString(s) <= maxLen {
+        return s
+    }
+    runes := []rune(s)
+    return string(runes[:maxLen-3]) + "..."
+}
+```
+
+After:
+```go
+func truncate(s string, maxWidth int) string {
+    if maxWidth < 4 || runewidth.StringWidth(s) <= maxWidth {
+        return s
+    }
+    return runewidth.Truncate(s, maxWidth, "...")
+}
+```
+
+### 3. Update `internal/output/text_test.go`
+
+**`TestTextFormatter_EmailListAlignmentMultiByteRunes`** (lines 876-921): Rewrite to verify display-column alignment by comparing two emails (one CJK, one ASCII) and checking their date columns align at the same display-column position using `runewidth.StringWidth`.
+
+**`TestTruncate`**: Add test cases for wide characters to verify cell-width-aware truncation.
+
+### Files modified
+
+- `go.mod` / `go.sum` (new dependency)
+- `internal/output/text.go` (width calculation, padding, truncation)
+- `internal/output/text_test.go` (update multi-byte test, add wide-char truncation cases)
+
+### Not changed
+
+- `formatMailboxes` uses `text/tabwriter`, which has its own byte-based width issues with CJK. That is a separate concern (tabwriter would need wrapping or replacement) and is out of scope.
+- `formatStats` only right-aligns integer counts (`%*d`), which are ASCII-only. No change needed.
+
+## Verification
+
+1. `go build ./...` -- compiles cleanly
+2. `go test ./internal/output/...` -- all tests pass, including updated multi-byte alignment test
+3. `go vet ./...` -- no issues
+4. Run project linters via `lint-and-fix`

--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,14 @@ go 1.24.7
 
 require (
 	git.sr.ht/~rockorager/go-jmap v0.5.3
+	github.com/mattn/go-runewidth v0.0.20
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 )
 
 require (
+	github.com/clipperhouse/uax29/v2 v2.2.0 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
@@ -17,7 +20,6 @@ require (
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/oauth2 v0.27.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 git.sr.ht/~rockorager/go-jmap v0.5.3 h1:PjnobX0ySPHKG5TiUqLM6PlM3ngYHlLJeWLOeorZ7IY=
 git.sr.ht/~rockorager/go-jmap v0.5.3/go.mod h1:aOTCtwpZSINpDDSOkLGpHU0Kbbm5lcSDMcobX3ZtOjY=
+github.com/clipperhouse/uax29/v2 v2.2.0 h1:ChwIKnQN3kcZteTXMgb1wztSgaU+ZemkgWdohwgs8tY=
+github.com/clipperhouse/uax29/v2 v2.2.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -17,6 +19,8 @@ github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/mattn/go-runewidth v0.0.20 h1:WcT52H91ZUAwy8+HUkdM3THM6gXqXuLJi9O3rjcQQaQ=
+github.com/mattn/go-runewidth v0.0.20/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
## Summary

- Replace `utf8.RuneCountInString` with `runewidth.StringWidth` for column width measurement in email list and dry-run formatters
- Replace `fmt.Sprintf("%%-%ds", ...)` padding with `runewidth.FillRight` for cell-width-aware column padding
- Rewrite `truncate` to use display columns instead of rune count, using `runewidth.Truncate`
- Add `github.com/mattn/go-runewidth` as a direct dependency

## Test plan

- [x] All existing tests pass (38/38), including updated wide-character alignment test
- [ ] Verify column alignment with CJK sender names in a terminal (e.g., `fm list` with East Asian contacts)
- [ ] Verify truncation works correctly for wide characters (sender names and subjects exceeding column limits)

## Closes

Closes #15