### PR TITLE
feat: replace static token with configurable credential command

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,17 @@
-# JMAP bearer token (required)
-# Generate at Fastmail: Settings > Privacy & Security > Integrations > API tokens
+# Shell command that prints the JMAP bearer token to stdout (required)
+# Generate a token at Fastmail: Settings > Privacy & Security > Integrations > API tokens
 # Required scopes: urn:ietf:params:jmap:core, urn:ietf:params:jmap:mail
-FM_TOKEN=
+#
+# Platform defaults (used when FM_CREDENTIAL_COMMAND is not set):
+#   macOS:  security find-generic-password -s fm -a fastmail -w
+#   Linux:  secret-tool lookup service fm
+#
+# Examples:
+#   FM_CREDENTIAL_COMMAND="security find-generic-password -s fm -a fastmail -w"
+#   FM_CREDENTIAL_COMMAND="secret-tool lookup service fm"
+#   FM_CREDENTIAL_COMMAND="op read op://Private/Fastmail/token"
+#   FM_CREDENTIAL_COMMAND="pass show fastmail/token"
+FM_CREDENTIAL_COMMAND=
 
 # JMAP session URL (default: Fastmail)
 # FM_SESSION_URL=https://api.fastmail.com/jmap/session

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ test: ## Run unit tests
 test-cli: binary ## Run scrut CLI integration tests
 	scrut test tests/errors.md tests/flags.md tests/arguments.md tests/help.md tests/sieve.md
 
-test-cli-live: binary ## Run opt-in live CLI integration tests (requires FM_TOKEN and FM_LIVE_TESTS=1)
+test-cli-live: binary ## Run opt-in live CLI integration tests (requires FM_CREDENTIAL_COMMAND and FM_LIVE_TESTS=1)
 	scrut test tests/live.md
 
 test-all: test test-cli ## Run all tests (unit + CLI)

--- a/README.md
+++ b/README.md
@@ -63,11 +63,26 @@ go install github.com/cboone/fm@latest
 2. Grant only these scopes:
    - `urn:ietf:params:jmap:core`
    - `urn:ietf:params:jmap:mail`
-3. Configure runtime secrets using environment variables:
+3. Store the token in your OS keychain:
+
+**macOS (Keychain):**
 
 ```bash
-export FM_TOKEN="fmu1-..."
-export FM_FORMAT="json"
+security add-generic-password -s fm -a fastmail -w "fmu1-..."
+```
+
+**Linux (libsecret):**
+
+```bash
+echo -n "fmu1-..." | secret-tool store --label "fm" service fm
+```
+
+On macOS and Linux, `fm` retrieves the token from the OS keychain by default. No extra configuration is needed.
+
+To use a different credential store, set a custom command:
+
+```bash
+export FM_CREDENTIAL_COMMAND="op read op://Private/Fastmail/token"
 ```
 
 4. Validate auth and endpoint:
@@ -183,29 +198,29 @@ For complete schemas and examples, see [docs/CLI-REFERENCE.md](docs/CLI-REFERENC
 
 Resolution order (highest first):
 
-1. Command flags (`--token`, `--format`, etc.)
-2. Environment variables (`FM_TOKEN`, `FM_FORMAT`, etc.)
+1. Command flags (`--credential-command`, `--format`, etc.)
+2. Environment variables (`FM_CREDENTIAL_COMMAND`, `FM_FORMAT`, etc.)
 3. Config file (`~/.config/fm/config.yaml`)
+4. Platform default (OS keychain on macOS and Linux)
 
 ### Environment Variables
 
-| Variable         | Description                     | Default                                 |
-| ---------------- | ------------------------------- | --------------------------------------- |
-| `FM_TOKEN`       | Bearer token for authentication | (none)                                  |
-| `FM_SESSION_URL` | JMAP session endpoint           | `https://api.fastmail.com/jmap/session` |
-| `FM_FORMAT`      | Output format: `json` or `text` | `json`                                  |
-| `FM_ACCOUNT_ID`  | JMAP account ID override        | (auto-detected)                         |
+| Variable                 | Description                                        | Default                                                |
+| ------------------------ | -------------------------------------------------- | ------------------------------------------------------ |
+| `FM_CREDENTIAL_COMMAND`  | Shell command that prints the API token to stdout   | macOS: OS keychain; Linux: libsecret; other: (none)    |
+| `FM_SESSION_URL`         | JMAP session endpoint                              | `https://api.fastmail.com/jmap/session`                |
+| `FM_FORMAT`              | Output format: `json` or `text`                    | `json`                                                 |
+| `FM_ACCOUNT_ID`          | JMAP account ID override                           | (auto-detected)                                        |
 
 ### Optional Config File
 
 ```yaml
 # ~/.config/fm/config.yaml
+credential_command: "op read op://Private/Fastmail/token"
 session_url: "https://api.fastmail.com/jmap/session"
 format: "json"
 account_id: ""
 ```
-
-Security note: keep tokens in environment variables, never in committed files.
 
 ## Claude Code Specific Notes
 

--- a/cmd/archive.go
+++ b/cmd/archive.go
@@ -21,7 +21,7 @@ var archiveCmd = &cobra.Command{
 		c, err := newClient()
 		if err != nil {
 			return exitError("authentication_failed", err.Error(),
-				"Check your token in FM_TOKEN or config file")
+				"Check your credential command or the token it returns")
 		}
 
 		archiveMB, err := c.GetMailboxByRole(mailbox.RoleArchive)

--- a/cmd/draft.go
+++ b/cmd/draft.go
@@ -71,7 +71,7 @@ It is NOT sent. Review and send from Fastmail.`,
 		c, err := newClient()
 		if err != nil {
 			return exitError("authentication_failed", err.Error(),
-				"Check your token in FM_TOKEN or config file")
+				"Check your credential command or the token it returns")
 		}
 
 		result, err := c.CreateDraft(client.DraftOptions{

--- a/cmd/dryrun_test.go
+++ b/cmd/dryrun_test.go
@@ -270,7 +270,7 @@ func commandArgsForServer(t *testing.T, serverURL string, commandArgs ...string)
 	base := []string{
 		"--config", configPath,
 		"--session-url", serverURL + "/session",
-		"--token", "test-token",
+		"--credential-command", "echo test-token",
 		"--account-id", "A1",
 		"--format", "json",
 	}

--- a/cmd/flag.go
+++ b/cmd/flag.go
@@ -35,7 +35,7 @@ var flagCmd = &cobra.Command{
 		c, err := newClient()
 		if err != nil {
 			return exitError("authentication_failed", err.Error(),
-				"Check your token in FM_TOKEN or config file")
+				"Check your credential command or the token it returns")
 		}
 
 		ids, err := resolveEmailIDs(cmd, args, c)

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -39,7 +39,7 @@ var listCmd = &cobra.Command{
 		c, err := newClient()
 		if err != nil {
 			return exitError("authentication_failed", err.Error(),
-				"Check your token in FM_TOKEN or config file")
+				"Check your credential command or the token it returns")
 		}
 
 		result, err := c.ListEmails(client.ListOptions{

--- a/cmd/mailboxes.go
+++ b/cmd/mailboxes.go
@@ -13,7 +13,7 @@ var mailboxesCmd = &cobra.Command{
 		c, err := newClient()
 		if err != nil {
 			return exitError("authentication_failed", err.Error(),
-				"Check your token in FM_TOKEN or config file")
+				"Check your credential command or the token it returns")
 		}
 
 		rolesOnly, _ := cmd.Flags().GetBool("roles-only")

--- a/cmd/mark-read.go
+++ b/cmd/mark-read.go
@@ -20,7 +20,7 @@ var markReadCmd = &cobra.Command{
 		c, err := newClient()
 		if err != nil {
 			return exitError("authentication_failed", err.Error(),
-				"Check your token in FM_TOKEN or config file")
+				"Check your credential command or the token it returns")
 		}
 
 		ids, err := resolveEmailIDs(cmd, args, c)

--- a/cmd/move.go
+++ b/cmd/move.go
@@ -29,7 +29,7 @@ Moving to Trash or Deleted Items is not permitted.`,
 		c, err := newClient()
 		if err != nil {
 			return exitError("authentication_failed", err.Error(),
-				"Check your token in FM_TOKEN or config file")
+				"Check your credential command or the token it returns")
 		}
 
 		targetMB, err := c.GetMailboxByNameOrID(target)

--- a/cmd/read.go
+++ b/cmd/read.go
@@ -16,7 +16,7 @@ var readCmd = &cobra.Command{
 		c, err := newClient()
 		if err != nil {
 			return exitError("authentication_failed", err.Error(),
-				"Check your token in FM_TOKEN or config file")
+				"Check your credential command or the token it returns")
 		}
 
 		emailID := args[0]

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -72,7 +72,7 @@ If omitted, only the provided flags/filters are used for matching.`,
 		c, err := newClient()
 		if err != nil {
 			return exitError("authentication_failed", err.Error(),
-				"Check your token in FM_TOKEN or config file")
+				"Check your credential command or the token it returns")
 		}
 
 		if mailboxName != "" {

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -13,7 +13,7 @@ var sessionCmd = &cobra.Command{
 		c, err := newClient()
 		if err != nil {
 			return exitError("authentication_failed", err.Error(),
-				"Check your token in FM_TOKEN or config file")
+				"Check your credential command or the token it returns")
 		}
 
 		info := c.SessionInfo()

--- a/cmd/sieve_activate.go
+++ b/cmd/sieve_activate.go
@@ -29,7 +29,7 @@ deactivates any currently active script.`,
 		c, err := newClient()
 		if err != nil {
 			return exitError("authentication_failed", err.Error(),
-				"Check your token in FM_TOKEN or config file")
+				"Check your credential command or the token it returns")
 		}
 
 		result, err := c.ActivateSieveScript(args[0])

--- a/cmd/sieve_create.go
+++ b/cmd/sieve_create.go
@@ -66,7 +66,7 @@ script deactivates the currently active one.`,
 		c, err := newClient()
 		if err != nil {
 			return exitError("authentication_failed", err.Error(),
-				"Check your token in FM_TOKEN or config file")
+				"Check your credential command or the token it returns")
 		}
 
 		result, err := c.CreateSieveScript(name, content, activate)

--- a/cmd/sieve_deactivate.go
+++ b/cmd/sieve_deactivate.go
@@ -24,7 +24,7 @@ var sieveDeactivateCmd = &cobra.Command{
 		c, err := newClient()
 		if err != nil {
 			return exitError("authentication_failed", err.Error(),
-				"Check your token in FM_TOKEN or config file")
+				"Check your credential command or the token it returns")
 		}
 
 		result, err := c.DeactivateSieveScript()

--- a/cmd/sieve_delete.go
+++ b/cmd/sieve_delete.go
@@ -29,7 +29,7 @@ Active scripts cannot be deleted. Use 'sieve deactivate' first.`,
 		c, err := newClient()
 		if err != nil {
 			return exitError("authentication_failed", err.Error(),
-				"Check your token in FM_TOKEN or config file")
+				"Check your credential command or the token it returns")
 		}
 
 		result, err := c.DeleteSieveScript(args[0])

--- a/cmd/sieve_list.go
+++ b/cmd/sieve_list.go
@@ -14,7 +14,7 @@ var sieveListCmd = &cobra.Command{
 		c, err := newClient()
 		if err != nil {
 			return exitError("authentication_failed", err.Error(),
-				"Check your token in FM_TOKEN or config file")
+				"Check your credential command or the token it returns")
 		}
 
 		result, err := c.ListSieveScripts()

--- a/cmd/sieve_show.go
+++ b/cmd/sieve_show.go
@@ -15,7 +15,7 @@ var sieveShowCmd = &cobra.Command{
 		c, err := newClient()
 		if err != nil {
 			return exitError("authentication_failed", err.Error(),
-				"Check your token in FM_TOKEN or config file")
+				"Check your credential command or the token it returns")
 		}
 
 		result, err := c.GetSieveScript(args[0])

--- a/cmd/sieve_validate.go
+++ b/cmd/sieve_validate.go
@@ -24,7 +24,7 @@ Provide the script content via --script or --script-stdin.`,
 		c, err := newClient()
 		if err != nil {
 			return exitError("authentication_failed", err.Error(),
-				"Check your token in FM_TOKEN or config file")
+				"Check your credential command or the token it returns")
 		}
 
 		result, err := c.ValidateSieveScript(content)

--- a/cmd/spam.go
+++ b/cmd/spam.go
@@ -21,7 +21,7 @@ var spamCmd = &cobra.Command{
 		c, err := newClient()
 		if err != nil {
 			return exitError("authentication_failed", err.Error(),
-				"Check your token in FM_TOKEN or config file")
+				"Check your credential command or the token it returns")
 		}
 
 		junkMB, err := c.GetMailboxByRole(mailbox.RoleJunk)

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -28,7 +28,7 @@ sorted by volume descending.`,
 		c, err := newClient()
 		if err != nil {
 			return exitError("authentication_failed", err.Error(),
-				"Check your token in FM_TOKEN or config file")
+				"Check your credential command or the token it returns")
 		}
 
 		mailboxID, err := c.ResolveMailboxID(mailboxName)

--- a/cmd/summary.go
+++ b/cmd/summary.go
@@ -33,7 +33,7 @@ detect newsletters. Provides a single-pass triage overview of a mailbox.`,
 		c, err := newClient()
 		if err != nil {
 			return exitError("authentication_failed", err.Error(),
-				"Check your token in FM_TOKEN or config file")
+				"Check your credential command or the token it returns")
 		}
 
 		mailboxID, err := c.ResolveMailboxID(mailboxName)

--- a/cmd/unflag.go
+++ b/cmd/unflag.go
@@ -22,7 +22,7 @@ var unflagCmd = &cobra.Command{
 		c, err := newClient()
 		if err != nil {
 			return exitError("authentication_failed", err.Error(),
-				"Check your token in FM_TOKEN or config file")
+				"Check your credential command or the token it returns")
 		}
 
 		ids, err := resolveEmailIDs(cmd, args, c)

--- a/docs/CLAUDE-CODE-GUIDE.md
+++ b/docs/CLAUDE-CODE-GUIDE.md
@@ -17,16 +17,24 @@ Create a Fastmail API token at **Settings > Privacy & Security > Integrations > 
 - `urn:ietf:params:jmap:core`
 - `urn:ietf:params:jmap:mail`
 
-Set it as an environment variable:
+Store it in your OS keychain:
+
+**macOS:**
 
 ```bash
-export FM_TOKEN="fmu1-..."
+security add-generic-password -s fm -a fastmail -w "fmu1-..."
 ```
 
-Or add it to `~/.config/fm/config.yaml`:
+**Linux:**
+
+```bash
+echo -n "fmu1-..." | secret-tool store --label "fm" service fm
+```
+
+Or configure a custom credential command in `~/.config/fm/config.yaml`:
 
 ```yaml
-token: "fmu1-..."
+credential_command: "op read op://Private/Fastmail/token"
 ```
 
 ### 3. Verify
@@ -244,7 +252,7 @@ All errors produce exit code 1. Structured error details are written to **stderr
 
 | Error code              | Meaning                     | Typical cause                          |
 | ----------------------- | --------------------------- | -------------------------------------- |
-| `authentication_failed` | Token is missing or invalid | `FM_TOKEN` not set or expired           |
+| `authentication_failed` | Token is missing or invalid | Credential command not configured or token expired |
 | `not_found`             | Email or mailbox not found  | Stale email ID or typo in mailbox name |
 | `forbidden_operation`   | Safety constraint triggered | Attempted to move to Trash             |
 

--- a/docs/CLI-REFERENCE.md
+++ b/docs/CLI-REFERENCE.md
@@ -6,7 +6,7 @@ Complete reference for all `fm` commands, flags, output schemas, and error codes
 
 | Flag            | Env Var            | Default                                 | Description                     |
 | --------------- | ------------------ | --------------------------------------- | ------------------------------- |
-| `--token`       | `FM_TOKEN`       | (none)                                  | Bearer token for authentication   |
+| `--credential-command` | `FM_CREDENTIAL_COMMAND` | OS keychain (macOS/Linux)      | Shell command that prints the API token to stdout |
 | `--session-url` | `FM_SESSION_URL` | `https://api.fastmail.com/jmap/session` | Fastmail session endpoint         |
 | `--format`      | `FM_FORMAT`      | `json`                                  | Output format: `json` or `text`   |
 | `--account-id`  | `FM_ACCOUNT_ID`  | (auto-detected)                         | Fastmail account ID override      |
@@ -1342,14 +1342,14 @@ When a hint is present:
 
 ```text
 Error [authentication_failed]: JMAP session request returned 401: invalid bearer token
-Hint: Check your token in FM_TOKEN or config file
+Hint: Check your credential command or the token it returns
 ```
 
 ### Error Codes
 
 | Code                    | Description                                         | Example hint                                               |
 | ----------------------- | --------------------------------------------------- | ---------------------------------------------------------- |
-| `authentication_failed` | Token is missing, invalid, or expired               | Check your token in FM_TOKEN or config file                |
+| `authentication_failed` | Token is missing, invalid, or expired               | Check your credential command or the token it returns      |
 | `not_found`             | Email ID or mailbox not found                       | (varies)                                                   |
 | `forbidden_operation`   | Attempted a disallowed action (e.g., move to Trash) | Deletion is not permitted by this tool                     |
 | `jmap_error`            | Server-side JMAP method error                       | (varies)                                                   |

--- a/tests/arguments.md
+++ b/tests/arguments.md
@@ -21,7 +21,7 @@ Error: accepts 1 arg(s), received 2
 ## Archive requires email IDs or filter flags
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm archive 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm archive 2>&1
 {
   "error": "general_error",
   "message": "no emails specified",
@@ -33,7 +33,7 @@ $ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexist
 ## Spam requires email IDs or filter flags
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm spam 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm spam 2>&1
 {
   "error": "general_error",
   "message": "no emails specified",
@@ -45,7 +45,7 @@ $ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexist
 ## Mark-read requires email IDs or filter flags
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm mark-read 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm mark-read 2>&1
 {
   "error": "general_error",
   "message": "no emails specified",
@@ -57,7 +57,7 @@ $ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexist
 ## Flag requires email IDs or filter flags
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm flag 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm flag 2>&1
 {
   "error": "general_error",
   "message": "no emails specified",
@@ -69,7 +69,7 @@ $ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexist
 ## Unflag requires email IDs or filter flags
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm unflag 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm unflag 2>&1
 {
   "error": "general_error",
   "message": "no emails specified",
@@ -81,7 +81,7 @@ $ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexist
 ## Move requires email IDs or filter flags
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm move 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm move 2>&1
 {
   "error": "general_error",
   "message": "no emails specified",
@@ -93,7 +93,7 @@ $ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexist
 ## Move requires --to flag
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm move M123 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm move M123 2>&1
 {
   "error": "general_error",
   "message": "required flag \"to\" not set",
@@ -124,7 +124,7 @@ Search without a positional query argument should still work (it fails
 due to no token, not due to argument validation).
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm search --from alice@test.com 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm search --from alice@test.com 2>&1
 {
   "error": "authentication_failed",
 * (glob+)
@@ -134,7 +134,7 @@ $ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexist
 ## Search accepts one argument
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm search "test query" --from alice@test.com 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm search "test query" --from alice@test.com 2>&1
 {
   "error": "authentication_failed",
 * (glob+)

--- a/tests/errors.md
+++ b/tests/errors.md
@@ -2,119 +2,119 @@
 
 Verify structured error output when things go wrong.
 
-## Missing token produces structured JSON error
+## Missing credential command produces structured JSON error
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm session 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm session 2>&1
 {
   "error": "authentication_failed",
-  "message": "no token configured; set FM_TOKEN, --token, or token in config file",
-  "hint": "Check your token in FM_TOKEN or config file"
+  "message": "credential command failed: *", (glob)
+  "hint": "Check your credential command or the token it returns"
 }
 [1]
 ```
 
-## Missing token with text format
+## Missing credential command with text format
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm session --format text 2>&1
-Error [authentication_failed]: no token configured; set FM_TOKEN, --token, or token in config file
-Hint: Check your token in FM_TOKEN or config file
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm session --format text 2>&1
+Error [authentication_failed]: credential command failed: * (glob)
+Hint: Check your credential command or the token it returns
 [1]
 ```
 
-## List without token
+## List without credential command
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm list 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm list 2>&1
 {
   "error": "authentication_failed",
-  "message": "no token configured; set FM_TOKEN, --token, or token in config file",
-  "hint": "Check your token in FM_TOKEN or config file"
+  "message": "credential command failed: *", (glob)
+  "hint": "Check your credential command or the token it returns"
 }
 [1]
 ```
 
-## Read without token
+## Read without credential command
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm read some-email-id 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm read some-email-id 2>&1
 {
   "error": "authentication_failed",
-  "message": "no token configured; set FM_TOKEN, --token, or token in config file",
-  "hint": "Check your token in FM_TOKEN or config file"
+  "message": "credential command failed: *", (glob)
+  "hint": "Check your credential command or the token it returns"
 }
 [1]
 ```
 
-## Search without token
+## Search without credential command
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm search "test query" 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm search "test query" 2>&1
 {
   "error": "authentication_failed",
-  "message": "no token configured; set FM_TOKEN, --token, or token in config file",
-  "hint": "Check your token in FM_TOKEN or config file"
+  "message": "credential command failed: *", (glob)
+  "hint": "Check your credential command or the token it returns"
 }
 [1]
 ```
 
-## Archive without token
+## Archive without credential command
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm archive M123 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm archive M123 2>&1
 {
   "error": "authentication_failed",
-  "message": "no token configured; set FM_TOKEN, --token, or token in config file",
-  "hint": "Check your token in FM_TOKEN or config file"
+  "message": "credential command failed: *", (glob)
+  "hint": "Check your credential command or the token it returns"
 }
 [1]
 ```
 
-## Spam without token
+## Spam without credential command
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm spam M123 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm spam M123 2>&1
 {
   "error": "authentication_failed",
-  "message": "no token configured; set FM_TOKEN, --token, or token in config file",
-  "hint": "Check your token in FM_TOKEN or config file"
+  "message": "credential command failed: *", (glob)
+  "hint": "Check your credential command or the token it returns"
 }
 [1]
 ```
 
-## Mark-read without token
+## Mark-read without credential command
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm mark-read M123 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm mark-read M123 2>&1
 {
   "error": "authentication_failed",
-  "message": "no token configured; set FM_TOKEN, --token, or token in config file",
-  "hint": "Check your token in FM_TOKEN or config file"
+  "message": "credential command failed: *", (glob)
+  "hint": "Check your credential command or the token it returns"
 }
 [1]
 ```
 
-## Move without token
+## Move without credential command
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm move M123 --to Archive 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm move M123 --to Archive 2>&1
 {
   "error": "authentication_failed",
-  "message": "no token configured; set FM_TOKEN, --token, or token in config file",
-  "hint": "Check your token in FM_TOKEN or config file"
+  "message": "credential command failed: *", (glob)
+  "hint": "Check your credential command or the token it returns"
 }
 [1]
 ```
 
-## Mailboxes without token
+## Mailboxes without credential command
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm mailboxes 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm mailboxes 2>&1
 {
   "error": "authentication_failed",
-  "message": "no token configured; set FM_TOKEN, --token, or token in config file",
-  "hint": "Check your token in FM_TOKEN or config file"
+  "message": "credential command failed: *", (glob)
+  "hint": "Check your credential command or the token it returns"
 }
 [1]
 ```
@@ -122,7 +122,7 @@ $ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexist
 ## Invalid token produces connection error
 
 ```scrut
-$ env -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm session --token "invalid-token-xxx" 2>&1
+$ env -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm session --credential-command "echo invalid-token-xxx" 2>&1
 {
   "error": "authentication_failed",
 * (glob+)

--- a/tests/flags.md
+++ b/tests/flags.md
@@ -14,11 +14,11 @@ fm version * (glob)
 The error output uses JSON format by default.
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm session 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm session 2>&1
 {
   "error": "authentication_failed",
-  "message": "no token configured; set FM_TOKEN, --token, or token in config file",
-  "hint": "Check your token in FM_TOKEN or config file"
+  "message": "credential command failed: *", (glob)
+  "hint": "Check your credential command or the token it returns"
 }
 [1]
 ```
@@ -26,38 +26,38 @@ $ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexist
 ## Format flag switches to text
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm session --format text 2>&1
-Error [authentication_failed]: no token configured; set FM_TOKEN, --token, or token in config file
-Hint: Check your token in FM_TOKEN or config file
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm session --format text 2>&1
+Error [authentication_failed]: credential command failed: * (glob)
+Hint: Check your credential command or the token it returns
 [1]
 ```
 
 ## FM_FORMAT env var switches to text
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_ACCOUNT_ID HOME=/nonexistent FM_FORMAT=text $TESTDIR/../fm session 2>&1
-Error [authentication_failed]: no token configured; set FM_TOKEN, --token, or token in config file
-Hint: Check your token in FM_TOKEN or config file
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_ACCOUNT_ID HOME=/nonexistent FM_FORMAT=text $TESTDIR/../fm session 2>&1
+Error [authentication_failed]: credential command failed: * (glob)
+Hint: Check your credential command or the token it returns
 [1]
 ```
 
-## FM_TOKEN env var is read
+## FM_CREDENTIAL_COMMAND env var is read
 
-When a token is set via env var, the error changes from "no token" to
-a connection/auth error.
+When a credential command is set via env var, the error changes from
+"credential command failed" to a connection/auth error.
 
 ```scrut
-$ env -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent FM_TOKEN=test-token $TESTDIR/../fm session 2>&1
+$ env -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent FM_CREDENTIAL_COMMAND="echo test-token" $TESTDIR/../fm session 2>&1
 {
   "error": "authentication_failed",
 * (glob+)
 [1]
 ```
 
-## Token flag overrides env var
+## Credential command flag overrides env var
 
 ```scrut
-$ env -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent FM_TOKEN=env-token $TESTDIR/../fm session --token flag-token 2>&1
+$ env -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent FM_CREDENTIAL_COMMAND="echo env-token" $TESTDIR/../fm session --credential-command "echo flag-token" 2>&1
 {
   "error": "authentication_failed",
 * (glob+)
@@ -67,7 +67,7 @@ $ env -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent FM_TOKEN
 ## Custom session URL via flag
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm session --token test --session-url http://localhost:1/jmap 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm session --credential-command "echo test" --session-url http://localhost:1/jmap 2>&1
 {
   "error": "authentication_failed",
 * (glob+)
@@ -77,7 +77,7 @@ $ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexist
 ## FM_SESSION_URL env var
 
 ```scrut
-$ env -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent FM_TOKEN=test FM_SESSION_URL=http://localhost:1/jmap $TESTDIR/../fm session 2>&1
+$ env -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent FM_CREDENTIAL_COMMAND="echo test" FM_SESSION_URL=http://localhost:1/jmap $TESTDIR/../fm session 2>&1
 {
   "error": "authentication_failed",
 * (glob+)
@@ -89,7 +89,7 @@ $ env -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent FM_TOKEN=test FM_SESSION_U
 List with default flags fails on auth, not on flag parsing.
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm list 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm list 2>&1
 {
   "error": "authentication_failed",
 * (glob+)
@@ -99,7 +99,7 @@ $ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexist
 ## List with all flags
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm list -m inbox -l 10 -o 5 -u -s "sentAt asc" 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm list -m inbox -l 10 -o 5 -u -s "sentAt asc" 2>&1
 {
   "error": "authentication_failed",
 * (glob+)
@@ -109,7 +109,7 @@ $ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexist
 ## Search with all filter flags
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm search "test" --from alice --to bob --subject meeting --before 2026-01-15T00:00:00Z --after 2025-12-01T00:00:00Z --has-attachment -l 10 -m inbox 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm search "test" --from alice --to bob --subject meeting --before 2026-01-15T00:00:00Z --after 2025-12-01T00:00:00Z --has-attachment -l 10 -m inbox 2>&1
 {
   "error": "authentication_failed",
 * (glob+)
@@ -119,7 +119,7 @@ $ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexist
 ## Search with bare date in --before flag
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm search --before 2026-02-01 --token test --session-url http://localhost:1/jmap 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm search --before 2026-02-01 --credential-command "echo test" --session-url http://localhost:1/jmap 2>&1
 {
   "error": "authentication_failed",
 * (glob+)
@@ -129,7 +129,7 @@ $ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexist
 ## Search with bare date in --after flag
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm search --after 2026-02-01 --token test --session-url http://localhost:1/jmap 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm search --after 2026-02-01 --credential-command "echo test" --session-url http://localhost:1/jmap 2>&1
 {
   "error": "authentication_failed",
 * (glob+)
@@ -139,7 +139,7 @@ $ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexist
 ## Search with invalid date format
 
 ```scrut
-$ env -u FM_TOKEN -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm search --before "not-a-date" --token test --session-url http://localhost:1/jmap 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm search --before "not-a-date" --credential-command "echo test" --session-url http://localhost:1/jmap 2>&1
 {
   "error": "general_error",
   "message": "invalid --before date: *", (glob)
@@ -162,7 +162,7 @@ $ $TESTDIR/../fm list --limit 0 2>&1
 ## Read with all flags
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm read M123 --html --raw-headers --thread 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm read M123 --html --raw-headers --thread 2>&1
 {
   "error": "authentication_failed",
 * (glob+)
@@ -172,7 +172,7 @@ $ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexist
 ## Mailboxes with roles-only flag
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm mailboxes --roles-only 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm mailboxes --roles-only 2>&1
 {
   "error": "authentication_failed",
 * (glob+)
@@ -182,7 +182,7 @@ $ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexist
 ## Dry-run flag on archive
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm archive --dry-run M1 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm archive --dry-run M1 2>&1
 {
   "error": "authentication_failed",
 * (glob+)
@@ -192,7 +192,7 @@ $ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexist
 ## Dry-run short flag on archive
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm archive -n M1 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm archive -n M1 2>&1
 {
   "error": "authentication_failed",
 * (glob+)
@@ -202,7 +202,7 @@ $ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexist
 ## Dry-run flag on spam
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm spam --dry-run M1 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm spam --dry-run M1 2>&1
 {
   "error": "authentication_failed",
 * (glob+)
@@ -212,7 +212,7 @@ $ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexist
 ## Dry-run short flag on spam
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm spam -n M1 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm spam -n M1 2>&1
 {
   "error": "authentication_failed",
 * (glob+)
@@ -222,7 +222,7 @@ $ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexist
 ## Dry-run flag on mark-read
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm mark-read --dry-run M1 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm mark-read --dry-run M1 2>&1
 {
   "error": "authentication_failed",
 * (glob+)
@@ -232,7 +232,7 @@ $ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexist
 ## Dry-run short flag on mark-read
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm mark-read -n M1 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm mark-read -n M1 2>&1
 {
   "error": "authentication_failed",
 * (glob+)
@@ -242,7 +242,7 @@ $ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexist
 ## Dry-run flag on flag
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm flag --dry-run M1 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm flag --dry-run M1 2>&1
 {
   "error": "authentication_failed",
 * (glob+)
@@ -252,7 +252,7 @@ $ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexist
 ## Dry-run short flag on flag
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm flag -n M1 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm flag -n M1 2>&1
 {
   "error": "authentication_failed",
 * (glob+)
@@ -262,7 +262,7 @@ $ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexist
 ## Dry-run flag on unflag
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm unflag --dry-run M1 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm unflag --dry-run M1 2>&1
 {
   "error": "authentication_failed",
 * (glob+)
@@ -272,7 +272,7 @@ $ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexist
 ## Dry-run short flag on unflag
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm unflag -n M1 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm unflag -n M1 2>&1
 {
   "error": "authentication_failed",
 * (glob+)
@@ -282,7 +282,7 @@ $ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexist
 ## Flag with --color accepts valid color
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm flag --color orange M1 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm flag --color orange M1 2>&1
 {
   "error": "authentication_failed",
 * (glob+)
@@ -292,7 +292,7 @@ $ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexist
 ## Flag with -c short flag
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm flag -c blue M1 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm flag -c blue M1 2>&1
 {
   "error": "authentication_failed",
 * (glob+)
@@ -314,7 +314,7 @@ $ $TESTDIR/../fm flag --color magenta M1 2>&1
 ## Unflag with --color accepts valid color
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm unflag --color M1 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm unflag --color M1 2>&1
 {
   "error": "authentication_failed",
 * (glob+)
@@ -324,7 +324,7 @@ $ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexist
 ## Unflag with --color and extra argument
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm unflag --color orange M1 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm unflag --color orange M1 2>&1
 {
   "error": "authentication_failed",
 * (glob+)
@@ -335,7 +335,7 @@ $ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexist
 ## Dry-run flag on move
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm move --dry-run M1 --to Receipts 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm move --dry-run M1 --to Receipts 2>&1
 {
   "error": "authentication_failed",
 * (glob+)
@@ -345,7 +345,7 @@ $ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexist
 ## Dry-run short flag on move
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm move -n M1 --to Receipts 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm move -n M1 --to Receipts 2>&1
 {
   "error": "authentication_failed",
 * (glob+)
@@ -355,7 +355,7 @@ $ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexist
 ## Archive with multiple IDs
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm archive M1 M2 M3 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm archive M1 M2 M3 2>&1
 {
   "error": "authentication_failed",
 * (glob+)
@@ -365,7 +365,7 @@ $ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexist
 ## Spam with multiple IDs
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm spam M1 M2 M3 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm spam M1 M2 M3 2>&1
 {
   "error": "authentication_failed",
 * (glob+)
@@ -375,7 +375,7 @@ $ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexist
 ## Mark-read with multiple IDs
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm mark-read M1 M2 M3 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm mark-read M1 M2 M3 2>&1
 {
   "error": "authentication_failed",
 * (glob+)
@@ -385,7 +385,7 @@ $ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexist
 ## Move with multiple IDs
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm move M1 M2 --to Receipts 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm move M1 M2 --to Receipts 2>&1
 {
   "error": "authentication_failed",
 * (glob+)
@@ -395,7 +395,7 @@ $ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexist
 ## Archive with filter flags produces auth error (not flag error)
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm archive --mailbox inbox --unread 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm archive --mailbox inbox --unread 2>&1
 {
   "error": "authentication_failed",
 * (glob+)
@@ -405,7 +405,7 @@ $ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexist
 ## Spam with filter flags produces auth error
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm spam --mailbox inbox --from notifications@github.com 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm spam --mailbox inbox --from notifications@github.com 2>&1
 {
   "error": "authentication_failed",
 * (glob+)
@@ -415,7 +415,7 @@ $ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexist
 ## Mark-read with filter flags produces auth error
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm mark-read --mailbox inbox --unread 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm mark-read --mailbox inbox --unread 2>&1
 {
   "error": "authentication_failed",
 * (glob+)
@@ -425,7 +425,7 @@ $ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexist
 ## IDs and filter flags are mutually exclusive
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm archive M1 --from alice@test.com 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm archive M1 --from alice@test.com 2>&1
 {
   "error": "general_error",
   "message": "cannot combine email IDs with filter flags",
@@ -437,7 +437,7 @@ $ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexist
 ## Flagged and unflagged are mutually exclusive on action commands
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm archive --flagged --unflagged 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm archive --flagged --unflagged 2>&1
 {
   "error": "general_error",
   "message": "--flagged and --unflagged are mutually exclusive"

--- a/tests/live.md
+++ b/tests/live.md
@@ -1,18 +1,18 @@
 # fm live integration tests
 
-These tests require a valid JMAP token and explicit opt-in.
+These tests require a valid credential command and explicit opt-in.
 They are skipped automatically when preconditions are not met.
 
 ## Preconditions
 
 Each test block below includes an inline precondition guard of the form:
-`test "$FM_LIVE_TESTS" = "1" -a -n "$FM_TOKEN" || exit 80`, so that
-live tests are only run when `FM_LIVE_TESTS=1` and `FM_TOKEN` is set.
+`test "$FM_LIVE_TESTS" = "1" -a -n "$FM_CREDENTIAL_COMMAND" || exit 80`, so that
+live tests are only run when `FM_LIVE_TESTS=1` and `FM_CREDENTIAL_COMMAND` is set.
 
 ## Session returns JSON with username
 
 ```scrut
-$ test "$FM_LIVE_TESTS" = "1" -a -n "$FM_TOKEN" || exit 80; $TESTDIR/../fm session --format json 2>&1
+$ test "$FM_LIVE_TESTS" = "1" -a -n "$FM_CREDENTIAL_COMMAND" || exit 80; $TESTDIR/../fm session --format json 2>&1
 {
   "username": *, (glob)
 * (glob+)
@@ -22,7 +22,7 @@ $ test "$FM_LIVE_TESTS" = "1" -a -n "$FM_TOKEN" || exit 80; $TESTDIR/../fm sessi
 ## Session with text format
 
 ```scrut
-$ test "$FM_LIVE_TESTS" = "1" -a -n "$FM_TOKEN" || exit 80; $TESTDIR/../fm session --format text 2>&1
+$ test "$FM_LIVE_TESTS" = "1" -a -n "$FM_CREDENTIAL_COMMAND" || exit 80; $TESTDIR/../fm session --format text 2>&1
 Username: * (glob)
 * (glob+)
 ```
@@ -30,7 +30,7 @@ Username: * (glob)
 ## Mailboxes returns JSON array
 
 ```scrut
-$ test "$FM_LIVE_TESTS" = "1" -a -n "$FM_TOKEN" || exit 80; $TESTDIR/../fm mailboxes --format json 2>&1
+$ test "$FM_LIVE_TESTS" = "1" -a -n "$FM_CREDENTIAL_COMMAND" || exit 80; $TESTDIR/../fm mailboxes --format json 2>&1
 [
 * (glob+)
   "id": *, (glob)
@@ -41,13 +41,13 @@ $ test "$FM_LIVE_TESTS" = "1" -a -n "$FM_TOKEN" || exit 80; $TESTDIR/../fm mailb
 ## Mailboxes roles-only entries all have role field
 
 ```scrut
-$ test "$FM_LIVE_TESTS" = "1" -a -n "$FM_TOKEN" || exit 80; $TESTDIR/../fm mailboxes --roles-only --format json | python3 -c 'import json,sys; data=json.load(sys.stdin); assert isinstance(data, list); assert data; assert all("role" in mb and mb["role"] for mb in data)'
+$ test "$FM_LIVE_TESTS" = "1" -a -n "$FM_CREDENTIAL_COMMAND" || exit 80; $TESTDIR/../fm mailboxes --roles-only --format json | python3 -c 'import json,sys; data=json.load(sys.stdin); assert isinstance(data, list); assert data; assert all("role" in mb and mb["role"] for mb in data)'
 ```
 
 ## List returns JSON with total and emails
 
 ```scrut
-$ test "$FM_LIVE_TESTS" = "1" -a -n "$FM_TOKEN" || exit 80; $TESTDIR/../fm list --limit 1 --format json 2>&1
+$ test "$FM_LIVE_TESTS" = "1" -a -n "$FM_CREDENTIAL_COMMAND" || exit 80; $TESTDIR/../fm list --limit 1 --format json 2>&1
 {
   "total": *, (glob)
   "offset": 0,
@@ -59,7 +59,7 @@ $ test "$FM_LIVE_TESTS" = "1" -a -n "$FM_TOKEN" || exit 80; $TESTDIR/../fm list 
 ## List with text format includes Total and ID lines
 
 ```scrut
-$ test "$FM_LIVE_TESTS" = "1" -a -n "$FM_TOKEN" || exit 80; $TESTDIR/../fm list --limit 1 --format text 2>&1
+$ test "$FM_LIVE_TESTS" = "1" -a -n "$FM_CREDENTIAL_COMMAND" || exit 80; $TESTDIR/../fm list --limit 1 --format text 2>&1
 Total: * (glob)
 * ID: * (glob)
 * (glob+)
@@ -68,7 +68,7 @@ Total: * (glob)
 ## Search with filter returns results for known sender
 
 ```scrut
-$ test "$FM_LIVE_TESTS" = "1" -a -n "$FM_TOKEN" || exit 80; SENDER=$($TESTDIR/../fm list --limit 10 --format json | python3 -c 'import json,sys; d=json.load(sys.stdin); print(next((addr["email"] for e in d.get("emails", []) for addr in e.get("from", []) if addr.get("email")), ""))'); test -n "$SENDER" || exit 80; $TESTDIR/../fm search --from "$SENDER" --limit 1 --format json 2>&1
+$ test "$FM_LIVE_TESTS" = "1" -a -n "$FM_CREDENTIAL_COMMAND" || exit 80; SENDER=$($TESTDIR/../fm list --limit 10 --format json | python3 -c 'import json,sys; d=json.load(sys.stdin); print(next((addr["email"] for e in d.get("emails", []) for addr in e.get("from", []) if addr.get("email")), ""))'); test -n "$SENDER" || exit 80; $TESTDIR/../fm search --from "$SENDER" --limit 1 --format json 2>&1
 {
   "total": *, (glob)
   "offset": 0,
@@ -79,7 +79,7 @@ $ test "$FM_LIVE_TESTS" = "1" -a -n "$FM_TOKEN" || exit 80; SENDER=$($TESTDIR/..
 ## Search with text query returns snippets
 
 ```scrut
-$ test "$FM_LIVE_TESTS" = "1" -a -n "$FM_TOKEN" || exit 80; TERM=$($TESTDIR/../fm list --limit 10 --format json | python3 -c 'import json,sys,re; d=json.load(sys.stdin); print(next((w.lower() for e in d.get("emails", []) for w in re.findall(r"[A-Za-z]{3,}", e.get("subject", ""))), "the"))'); test -n "$TERM" || exit 80; $TESTDIR/../fm search "$TERM" --limit 1 --format json 2>&1
+$ test "$FM_LIVE_TESTS" = "1" -a -n "$FM_CREDENTIAL_COMMAND" || exit 80; TERM=$($TESTDIR/../fm list --limit 10 --format json | python3 -c 'import json,sys,re; d=json.load(sys.stdin); print(next((w.lower() for e in d.get("emails", []) for w in re.findall(r"[A-Za-z]{3,}", e.get("subject", ""))), "the"))'); test -n "$TERM" || exit 80; $TESTDIR/../fm search "$TERM" --limit 1 --format json 2>&1
 {
   "total": *, (glob)
   "offset": 0,
@@ -92,7 +92,7 @@ $ test "$FM_LIVE_TESTS" = "1" -a -n "$FM_TOKEN" || exit 80; TERM=$($TESTDIR/../f
 ## Read known email ID returns body
 
 ```scrut
-$ test "$FM_LIVE_TESTS" = "1" -a -n "$FM_TOKEN" || exit 80; EMAIL_ID=$($TESTDIR/../fm list --limit 1 --format json | python3 -c 'import json,sys; d=json.load(sys.stdin); emails=d.get("emails", []); print(emails[0]["id"] if emails else "")'); test -n "$EMAIL_ID" || exit 80; $TESTDIR/../fm read "$EMAIL_ID" --format json 2>&1
+$ test "$FM_LIVE_TESTS" = "1" -a -n "$FM_CREDENTIAL_COMMAND" || exit 80; EMAIL_ID=$($TESTDIR/../fm list --limit 1 --format json | python3 -c 'import json,sys; d=json.load(sys.stdin); emails=d.get("emails", []); print(emails[0]["id"] if emails else "")'); test -n "$EMAIL_ID" || exit 80; $TESTDIR/../fm read "$EMAIL_ID" --format json 2>&1
 {
   "id": *, (glob)
 * (glob+)
@@ -104,7 +104,7 @@ $ test "$FM_LIVE_TESTS" = "1" -a -n "$FM_TOKEN" || exit 80; EMAIL_ID=$($TESTDIR/
 ## Mailboxes text format shows tabular output
 
 ```scrut
-$ test "$FM_LIVE_TESTS" = "1" -a -n "$FM_TOKEN" || exit 80; $TESTDIR/../fm mailboxes --format text 2>&1
+$ test "$FM_LIVE_TESTS" = "1" -a -n "$FM_CREDENTIAL_COMMAND" || exit 80; $TESTDIR/../fm mailboxes --format text 2>&1
 * total:* unread:* (glob)
 * (glob+)
 ```
@@ -112,7 +112,7 @@ $ test "$FM_LIVE_TESTS" = "1" -a -n "$FM_TOKEN" || exit 80; $TESTDIR/../fm mailb
 ## Mark-read marks an email as read
 
 ```scrut
-$ test "$FM_LIVE_TESTS" = "1" -a -n "$FM_TOKEN" || exit 80; EMAIL_ID=$($TESTDIR/../fm list --unread --limit 1 --format json | python3 -c 'import json,sys; d=json.load(sys.stdin); emails=d.get("emails", []); print(emails[0]["id"] if emails else "")'); test -n "$EMAIL_ID" || exit 80; $TESTDIR/../fm mark-read "$EMAIL_ID" --format json 2>&1
+$ test "$FM_LIVE_TESTS" = "1" -a -n "$FM_CREDENTIAL_COMMAND" || exit 80; EMAIL_ID=$($TESTDIR/../fm list --unread --limit 1 --format json | python3 -c 'import json,sys; d=json.load(sys.stdin); emails=d.get("emails", []); print(emails[0]["id"] if emails else "")'); test -n "$EMAIL_ID" || exit 80; $TESTDIR/../fm mark-read "$EMAIL_ID" --format json 2>&1
 {
   "matched": 1,
   "processed": 1,
@@ -127,13 +127,13 @@ $ test "$FM_LIVE_TESTS" = "1" -a -n "$FM_TOKEN" || exit 80; EMAIL_ID=$($TESTDIR/
 ## Mark-read removes the email from unread results
 
 ```scrut
-$ test "$FM_LIVE_TESTS" = "1" -a -n "$FM_TOKEN" || exit 80; EMAIL_ID=$($TESTDIR/../fm list --unread --limit 1 --format json | python3 -c 'import json,sys; d=json.load(sys.stdin); emails=d.get("emails", []); print(emails[0]["id"] if emails else "")'); test -n "$EMAIL_ID" || exit 80; $TESTDIR/../fm mark-read "$EMAIL_ID" --format json >/dev/null; $TESTDIR/../fm list --unread --limit 50 --format json | python3 -c 'import json,sys; target=sys.argv[1]; d=json.load(sys.stdin); ids={e.get("id") for e in d.get("emails", [])}; assert target not in ids, f"{target} is still unread"' "$EMAIL_ID"
+$ test "$FM_LIVE_TESTS" = "1" -a -n "$FM_CREDENTIAL_COMMAND" || exit 80; EMAIL_ID=$($TESTDIR/../fm list --unread --limit 1 --format json | python3 -c 'import json,sys; d=json.load(sys.stdin); emails=d.get("emails", []); print(emails[0]["id"] if emails else "")'); test -n "$EMAIL_ID" || exit 80; $TESTDIR/../fm mark-read "$EMAIL_ID" --format json >/dev/null; $TESTDIR/../fm list --unread --limit 50 --format json | python3 -c 'import json,sys; target=sys.argv[1]; d=json.load(sys.stdin); ids={e.get("id") for e in d.get("emails", [])}; assert target not in ids, f"{target} is still unread"' "$EMAIL_ID"
 ```
 
 ## Error in text format uses Error prefix
 
 ```scrut
-$ test "$FM_LIVE_TESTS" = "1" || exit 80; $TESTDIR/../fm session --format text --token bad-token --session-url http://localhost:1/jmap 2>&1
+$ test "$FM_LIVE_TESTS" = "1" || exit 80; $TESTDIR/../fm session --format text --credential-command "echo bad-token" --session-url http://localhost:1/jmap 2>&1
 Error [authentication_failed]: * (glob)
 * (glob+)
 [1]

--- a/tests/sieve.md
+++ b/tests/sieve.md
@@ -127,26 +127,26 @@ Flags: (glob)
 * (glob*)
 ```
 
-## Sieve list without token
+## Sieve list without credential command
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm sieve list 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm sieve list 2>&1
 {
   "error": "authentication_failed",
-  "message": "no token configured; set FM_TOKEN, --token, or token in config file",
-  "hint": "Check your token in FM_TOKEN or config file"
+  "message": "credential command failed: *", (glob)
+  "hint": "Check your credential command or the token it returns"
 }
 [1]
 ```
 
-## Sieve show without token
+## Sieve show without credential command
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm sieve show S1 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm sieve show S1 2>&1
 {
   "error": "authentication_failed",
-  "message": "no token configured; set FM_TOKEN, --token, or token in config file",
-  "hint": "Check your token in FM_TOKEN or config file"
+  "message": "credential command failed: *", (glob)
+  "hint": "Check your credential command or the token it returns"
 }
 [1]
 ```
@@ -162,7 +162,7 @@ Error: accepts 1 arg(s), received 0
 ## Sieve create requires name
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm sieve create --from "a@b.com" --action junk 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm sieve create --from "a@b.com" --action junk 2>&1
 {
   "error": "general_error",
   "message": "required flag \"name\" not set",
@@ -174,7 +174,7 @@ $ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexist
 ## Sieve create requires template flags or stdin
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm sieve create --name "test" 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm sieve create --name "test" 2>&1
 {
   "error": "general_error",
   "message": "provide either template flags (--from/--from-domain + --action) or --script-stdin"
@@ -201,7 +201,7 @@ Error: accepts 1 arg(s), received 0
 ## Sieve validate requires script input
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm sieve validate 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm sieve validate 2>&1
 {
   "error": "general_error",
   "message": "either --script or --script-stdin is required"
@@ -212,7 +212,7 @@ $ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexist
 ## Sieve create dry-run shows generated script
 
 ```scrut
-$ env -u FM_TOKEN -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm sieve create --name "Block spam" --from "spam@example.com" --action junk --dry-run 2>&1
+$ env -u FM_CREDENTIAL_COMMAND -u FM_SESSION_URL -u FM_FORMAT -u FM_ACCOUNT_ID HOME=/nonexistent $TESTDIR/../fm sieve create --name "Block spam" --from "spam@example.com" --action junk --dry-run 2>&1
 {
   "operation": "create",
   "script": "Block spam",


### PR DESCRIPTION
Replace --token/FM_TOKEN with --credential-command/FM_CREDENTIAL_COMMAND
that executes a user-specified shell command to retrieve the API token.
This allows integration with any secret store (macOS Keychain, libsecret,
1Password CLI, pass, etc.).

Platform defaults retrieve the token from the OS keychain automatically:
- macOS: security find-generic-password -s fm -a fastmail -w
- Linux: secret-tool lookup service fm

https://claude.ai/code/session_01Cim6GJ6UqAkHeetJSdRgNK