### PR TITLE
fix: remove undeclared GITHUB_TOKEN from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,5 +11,4 @@ jobs:
   release:
     uses: cboone/gh-actions/.github/workflows/go-release.yml@main
     secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}


### PR DESCRIPTION
## Summary

- Remove `GITHUB_TOKEN` secret from `go-release.yml` caller
- The reusable workflow uses `github.token` directly and does not declare `GITHUB_TOKEN` as a secret; passing it would cause a workflow validation error on tag push

## Test plan

- [ ] Verify next release tag push succeeds