### PR TITLE
chore: pin gh-actions to v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   ci:
-    uses: cboone/gh-actions/.github/workflows/go-ci.yml@main
+    uses: cboone/gh-actions/.github/workflows/go-ci.yml@v1
     with:
       run-scrut: true
       scrut-build-cmd: "go build ."

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -9,6 +9,6 @@ on:
 
 jobs:
   gitleaks:
-    uses: cboone/gh-actions/.github/workflows/secret-scan.yml@main
+    uses: cboone/gh-actions/.github/workflows/secret-scan.yml@v1
     with:
       tool: gitleaks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,6 @@ permissions:
 
 jobs:
   release:
-    uses: cboone/gh-actions/.github/workflows/go-release.yml@main
+    uses: cboone/gh-actions/.github/workflows/go-release.yml@v1
     secrets:
       HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}


### PR DESCRIPTION
## Summary

- Pin `cboone/gh-actions` references from `@main` to `@v1`

The gh-actions repo has been tagged with v1.0.0. Using the floating `@v1` tag ensures we automatically pick up non-breaking updates while maintaining stability.