### PR TITLE
Compact text output for action commands

### DIFF
--- a/docs/CLI-REFERENCE.md
+++ b/docs/CLI-REFERENCE.md
@@ -676,12 +676,10 @@ Email IDs and filter flags are mutually exclusive.
 **Text output:**
 
 ```text
-Matched: 2, Processed: 2, Failed: 0
-Archived: M-email-id-1, M-email-id-2
-Destination: Archive (mb-archive-id)
+Archived 2 of 2 matched emails (0 failed)
 ```
 
-If some emails fail, the successful ones are still listed and errors appear in the `errors` array. A `partial_failure` error is also written to stderr.
+If some emails fail, the error count is shown and individual errors are listed. A `partial_failure` error is also written to stderr.
 
 ---
 
@@ -731,12 +729,10 @@ Email IDs and filter flags are mutually exclusive.
 **Text output:**
 
 ```text
-Matched: 1, Processed: 1, Failed: 0
-Marked as spam: M-email-id-1
-Destination: Junk Mail (mb-junk-id)
+Marked as spam 1 of 1 matched emails (0 failed)
 ```
 
-If some emails fail, the successful ones are still listed and errors appear in the `errors` array. A `partial_failure` error is also written to stderr.
+If some emails fail, the error count is shown and individual errors are listed. A `partial_failure` error is also written to stderr.
 
 ---
 
@@ -783,11 +779,10 @@ Email IDs and filter flags are mutually exclusive.
 **Text output:**
 
 ```text
-Matched: 2, Processed: 2, Failed: 0
-Marked as read: M-email-id-1, M-email-id-2
+Marked as read 2 of 2 matched emails (0 failed)
 ```
 
-If some emails fail, the successful ones are still listed and errors appear in the `errors` array. A `partial_failure` error is also written to stderr.
+If some emails fail, the error count is shown and individual errors are listed. A `partial_failure` error is also written to stderr.
 
 ---
 
@@ -845,11 +840,10 @@ fm flag M-email-id                  # flag without color (existing behavior)
 **Text output:**
 
 ```text
-Matched: 2, Processed: 2, Failed: 0
-Flagged: M-email-id-1, M-email-id-2
+Flagged 2 of 2 matched emails (0 failed)
 ```
 
-If some emails fail, the successful ones are still listed and errors appear in the `errors` array. A `partial_failure` error is also written to stderr.
+If some emails fail, the error count is shown and individual errors are listed. A `partial_failure` error is also written to stderr.
 
 ---
 
@@ -906,11 +900,10 @@ fm unflag --color M-email-id         # remove color only, keep flagged
 **Text output:**
 
 ```text
-Matched: 2, Processed: 2, Failed: 0
-Unflagged: M-email-id-1, M-email-id-2
+Unflagged 2 of 2 matched emails (0 failed)
 ```
 
-If some emails fail, the successful ones are still listed and errors appear in the `errors` array. A `partial_failure` error is also written to stderr.
+If some emails fail, the error count is shown and individual errors are listed. A `partial_failure` error is also written to stderr.
 
 ---
 
@@ -964,12 +957,10 @@ The `--to` flag on `move` is the destination mailbox, not a recipient filter. To
 **Text output:**
 
 ```text
-Matched: 1, Processed: 1, Failed: 0
-Moved: M-email-id-1
-Destination: Receipts (mb-receipts-id)
+Moved 1 of 1 matched emails to Receipts (0 failed)
 ```
 
-If some emails fail, the successful ones are still listed and errors appear in the `errors` array. A `partial_failure` error is also written to stderr.
+If some emails fail, the error count is shown and individual errors are listed. A `partial_failure` error is also written to stderr.
 
 ---
 

--- a/docs/plans/done/2026-03-27-compact-text-output-for-action-commands.md
+++ b/docs/plans/done/2026-03-27-compact-text-output-for-action-commands.md
@@ -1,0 +1,87 @@
+# Compact text output for action commands (#71)
+
+## Context
+
+Action commands (`archive`, `spam`, `flag`, `unflag`, `mark-read`, `move`) produce verbose output that lists every processed email ID. Even with `--format text`, the output includes all IDs, which is unusable for bulk operations (e.g., 527 IDs from a single archive command). During a triage session processing ~1,800 emails across 60+ senders, every action command had to be piped through Python just to extract counts.
+
+The fix: make the text formatter produce a compact one-line summary for `MoveResult`, while keeping JSON output unchanged for programmatic use.
+
+## Approach
+
+Modify the existing `TextFormatter.formatMoveResult` in `internal/output/text.go` to produce a compact summary instead of listing every ID. No new format type, no changes to the `Formatter` interface, no changes to `MoveResult` struct or action command files.
+
+### Output format
+
+**No destination (flag, unflag, mark-read):**
+```
+Flagged 2 of 2 matched emails (0 failed)
+```
+
+**With destination, move only:**
+```
+Moved 5 of 5 matched emails to Receipts (0 failed)
+```
+
+**With destination, archive/spam (verb implies destination):**
+```
+Archived 527 of 527 matched emails (0 failed)
+```
+
+**Partial failure:**
+```
+Archived 526 of 527 matched emails (1 failed)
+Errors:
+  - M42: not found
+```
+
+### Verb mapping
+
+Determined from which `MoveResult` slice field is populated:
+
+| Field          | Verb             |
+| -------------- | ---------------- |
+| `Archived`     | "Archived"       |
+| `MarkedSpam`   | "Marked as spam" |
+| `MarkedAsRead` | "Marked as read" |
+| `Flagged`      | "Flagged"        |
+| `Unflagged`    | "Unflagged"      |
+| `Moved`        | "Moved"          |
+| (none/default) | "Processed"      |
+
+The default case handles all-failed scenarios where no action slice is populated.
+
+## Changes
+
+### 1. `internal/output/text.go` (lines 211-241)
+
+- Add private `actionVerb(r types.MoveResult) (string, int)` helper before `formatMoveResult`
+- Rewrite `formatMoveResult` to:
+  1. Call `actionVerb` to get the verb and success count
+  2. Print one summary line (with "to {Name}" suffix only for `Moved` with a destination)
+  3. Print errors block if any
+
+### 2. `internal/output/text_test.go` (lines 423-559)
+
+- Update 6 existing `MoveResult` tests to expect compact output instead of ID lists
+- Fix incomplete test fixtures (several tests omit `Matched`/`Processed` fields)
+- Add `TestTextFormatter_MoveResultAllFailed` for the all-failed edge case
+- Add `TestTextFormatter_MoveResultMovedWithDestination` for the move-specific "to Name" format
+
+### 3. `docs/CLI-REFERENCE.md`
+
+Update the "Text output" blocks for all 6 action commands (lines 676-682, 731-737, 783-788, 845-850, 906-911, 964-970) to show the compact format.
+
+## Files not changed
+
+- `internal/types/types.go`: `MoveResult` struct is unchanged. ID slices still populated and serialized to JSON.
+- `internal/output/json.go`: JSON output retains full detail including all IDs.
+- `internal/output/formatter.go`: No changes to the interface or factory.
+- `cmd/root.go`: Format flag validation unchanged (still "json" or "text").
+- `cmd/archive.go`, `cmd/spam.go`, `cmd/flag.go`, `cmd/unflag.go`, `cmd/mark-read.go`, `cmd/move.go`: No changes. All continue to populate `MoveResult` the same way.
+
+## Verification
+
+1. `go build ./...` compiles without errors
+2. `go test ./...` passes all tests
+3. `go vet ./...` reports no issues
+4. Run project linters (`lint-and-fix`)

--- a/internal/output/text.go
+++ b/internal/output/text.go
@@ -210,17 +210,17 @@ func (f *TextFormatter) formatThreadView(w io.Writer, tv types.ThreadView) error
 
 func actionVerb(r types.MoveResult) (string, int) {
 	switch {
-	case len(r.Archived) > 0:
+	case r.Archived != nil:
 		return "Archived", len(r.Archived)
-	case len(r.MarkedSpam) > 0:
+	case r.MarkedSpam != nil:
 		return "Marked as spam", len(r.MarkedSpam)
-	case len(r.MarkedAsRead) > 0:
+	case r.MarkedAsRead != nil:
 		return "Marked as read", len(r.MarkedAsRead)
-	case len(r.Flagged) > 0:
+	case r.Flagged != nil:
 		return "Flagged", len(r.Flagged)
-	case len(r.Unflagged) > 0:
+	case r.Unflagged != nil:
 		return "Unflagged", len(r.Unflagged)
-	case len(r.Moved) > 0:
+	case r.Moved != nil:
 		return "Moved", len(r.Moved)
 	default:
 		return "Processed", r.Processed - r.Failed

--- a/internal/output/text.go
+++ b/internal/output/text.go
@@ -230,7 +230,7 @@ func actionVerb(r types.MoveResult) (string, int) {
 func (f *TextFormatter) formatMoveResult(w io.Writer, r types.MoveResult) error {
 	verb, count := actionVerb(r)
 
-	if verb == "Moved" && r.Destination != nil {
+	if r.Moved != nil && r.Destination != nil {
 		_, _ = fmt.Fprintf(w, "%s %d of %d matched emails to %s (%d failed)\n",
 			verb, count, r.Matched, r.Destination.Name, r.Failed)
 	} else {

--- a/internal/output/text.go
+++ b/internal/output/text.go
@@ -208,29 +208,36 @@ func (f *TextFormatter) formatThreadView(w io.Writer, tv types.ThreadView) error
 	return f.formatEmailDetail(w, tv.Email)
 }
 
+func actionVerb(r types.MoveResult) (string, int) {
+	switch {
+	case len(r.Archived) > 0:
+		return "Archived", len(r.Archived)
+	case len(r.MarkedSpam) > 0:
+		return "Marked as spam", len(r.MarkedSpam)
+	case len(r.MarkedAsRead) > 0:
+		return "Marked as read", len(r.MarkedAsRead)
+	case len(r.Flagged) > 0:
+		return "Flagged", len(r.Flagged)
+	case len(r.Unflagged) > 0:
+		return "Unflagged", len(r.Unflagged)
+	case len(r.Moved) > 0:
+		return "Moved", len(r.Moved)
+	default:
+		return "Processed", r.Processed - r.Failed
+	}
+}
+
 func (f *TextFormatter) formatMoveResult(w io.Writer, r types.MoveResult) error {
-	_, _ = fmt.Fprintf(w, "Matched: %d, Processed: %d, Failed: %d\n", r.Matched, r.Processed, r.Failed)
-	if len(r.Archived) > 0 {
-		_, _ = fmt.Fprintf(w, "Archived: %s\n", strings.Join(r.Archived, ", "))
+	verb, count := actionVerb(r)
+
+	if verb == "Moved" && r.Destination != nil {
+		_, _ = fmt.Fprintf(w, "%s %d of %d matched emails to %s (%d failed)\n",
+			verb, count, r.Matched, r.Destination.Name, r.Failed)
+	} else {
+		_, _ = fmt.Fprintf(w, "%s %d of %d matched emails (%d failed)\n",
+			verb, count, r.Matched, r.Failed)
 	}
-	if len(r.MarkedSpam) > 0 {
-		_, _ = fmt.Fprintf(w, "Marked as spam: %s\n", strings.Join(r.MarkedSpam, ", "))
-	}
-	if len(r.MarkedAsRead) > 0 {
-		_, _ = fmt.Fprintf(w, "Marked as read: %s\n", strings.Join(r.MarkedAsRead, ", "))
-	}
-	if len(r.Flagged) > 0 {
-		_, _ = fmt.Fprintf(w, "Flagged: %s\n", strings.Join(r.Flagged, ", "))
-	}
-	if len(r.Unflagged) > 0 {
-		_, _ = fmt.Fprintf(w, "Unflagged: %s\n", strings.Join(r.Unflagged, ", "))
-	}
-	if len(r.Moved) > 0 {
-		_, _ = fmt.Fprintf(w, "Moved: %s\n", strings.Join(r.Moved, ", "))
-	}
-	if r.Destination != nil {
-		_, _ = fmt.Fprintf(w, "Destination: %s (%s)\n", r.Destination.Name, r.Destination.ID)
-	}
+
 	if len(r.Errors) > 0 {
 		_, _ = fmt.Fprintf(w, "Errors:\n")
 		for _, e := range r.Errors {

--- a/internal/output/text_test.go
+++ b/internal/output/text_test.go
@@ -564,7 +564,7 @@ func TestTextFormatter_MoveResultUnflagged(t *testing.T) {
 	}
 }
 
-func TestTextFormatter_MoveResultAllFailed(t *testing.T) {
+func TestTextFormatter_MoveResultNoActionSlice(t *testing.T) {
 	f := &TextFormatter{}
 	var buf bytes.Buffer
 
@@ -582,6 +582,31 @@ func TestTextFormatter_MoveResultAllFailed(t *testing.T) {
 	out := buf.String()
 	if !strings.Contains(out, "Processed 0 of 2 matched emails (2 failed)") {
 		t.Errorf("expected fallback summary, got: %s", out)
+	}
+	if !strings.Contains(out, "M1: server error") {
+		t.Errorf("expected error detail, got: %s", out)
+	}
+}
+
+func TestTextFormatter_MoveResultAllFailed(t *testing.T) {
+	f := &TextFormatter{}
+	var buf bytes.Buffer
+
+	result := types.MoveResult{
+		Matched:   2,
+		Processed: 2,
+		Failed:    2,
+		Archived:  []string{},
+		Errors:    []string{"M1: server error", "M2: server error"},
+	}
+
+	if err := f.Format(&buf, result); err != nil {
+		t.Fatal(err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Archived 0 of 2 matched emails (2 failed)") {
+		t.Errorf("expected action verb with zero success, got: %s", out)
 	}
 	if !strings.Contains(out, "M1: server error") {
 		t.Errorf("expected error detail, got: %s", out)

--- a/internal/output/text_test.go
+++ b/internal/output/text_test.go
@@ -440,14 +440,11 @@ func TestTextFormatter_MoveResult(t *testing.T) {
 	}
 
 	out := buf.String()
-	if !strings.Contains(out, "Matched: 2, Processed: 2, Failed: 0") {
-		t.Errorf("expected summary line, got: %s", out)
+	if !strings.Contains(out, "Archived 2 of 2 matched emails (0 failed)") {
+		t.Errorf("expected compact summary, got: %s", out)
 	}
-	if !strings.Contains(out, "Archived: M1, M2") {
-		t.Errorf("expected archived IDs, got: %s", out)
-	}
-	if !strings.Contains(out, "Archive") {
-		t.Errorf("expected destination name, got: %s", out)
+	if strings.Contains(out, "M1") || strings.Contains(out, "M2") {
+		t.Errorf("should not list individual IDs, got: %s", out)
 	}
 }
 
@@ -471,11 +468,8 @@ func TestTextFormatter_MoveResultWithErrors(t *testing.T) {
 	}
 
 	out := buf.String()
-	if !strings.Contains(out, "Matched: 2, Processed: 2, Failed: 1") {
-		t.Errorf("expected summary line, got: %s", out)
-	}
-	if !strings.Contains(out, "Moved: M1") {
-		t.Errorf("expected moved IDs, got: %s", out)
+	if !strings.Contains(out, "Moved 1 of 2 matched emails to Receipts (1 failed)") {
+		t.Errorf("expected compact summary with destination, got: %s", out)
 	}
 	if !strings.Contains(out, "M2: not found") {
 		t.Errorf("expected error detail, got: %s", out)
@@ -487,6 +481,9 @@ func TestTextFormatter_MoveResultSpam(t *testing.T) {
 	var buf bytes.Buffer
 
 	result := types.MoveResult{
+		Matched:    1,
+		Processed:  1,
+		Failed:     0,
 		MarkedSpam: []string{"M1"},
 		Errors:     []string{},
 	}
@@ -496,8 +493,8 @@ func TestTextFormatter_MoveResultSpam(t *testing.T) {
 	}
 
 	out := buf.String()
-	if !strings.Contains(out, "Marked as spam: M1") {
-		t.Errorf("expected spam IDs, got: %s", out)
+	if !strings.Contains(out, "Marked as spam 1 of 1 matched emails (0 failed)") {
+		t.Errorf("expected compact summary, got: %s", out)
 	}
 }
 
@@ -506,6 +503,9 @@ func TestTextFormatter_MoveResultMarkedAsRead(t *testing.T) {
 	var buf bytes.Buffer
 
 	result := types.MoveResult{
+		Matched:      2,
+		Processed:    2,
+		Failed:       0,
 		MarkedAsRead: []string{"M1", "M2"},
 		Errors:       []string{},
 	}
@@ -515,8 +515,8 @@ func TestTextFormatter_MoveResultMarkedAsRead(t *testing.T) {
 	}
 
 	out := buf.String()
-	if !strings.Contains(out, "Marked as read: M1, M2") {
-		t.Errorf("expected marked-as-read IDs, got: %s", out)
+	if !strings.Contains(out, "Marked as read 2 of 2 matched emails (0 failed)") {
+		t.Errorf("expected compact summary, got: %s", out)
 	}
 }
 
@@ -525,8 +525,11 @@ func TestTextFormatter_MoveResultFlagged(t *testing.T) {
 	var buf bytes.Buffer
 
 	result := types.MoveResult{
-		Flagged: []string{"M1", "M2"},
-		Errors:  []string{},
+		Matched:   2,
+		Processed: 2,
+		Failed:    0,
+		Flagged:   []string{"M1", "M2"},
+		Errors:    []string{},
 	}
 
 	if err := f.Format(&buf, result); err != nil {
@@ -534,8 +537,8 @@ func TestTextFormatter_MoveResultFlagged(t *testing.T) {
 	}
 
 	out := buf.String()
-	if !strings.Contains(out, "Flagged: M1, M2") {
-		t.Errorf("expected flagged IDs, got: %s", out)
+	if !strings.Contains(out, "Flagged 2 of 2 matched emails (0 failed)") {
+		t.Errorf("expected compact summary, got: %s", out)
 	}
 }
 
@@ -544,6 +547,9 @@ func TestTextFormatter_MoveResultUnflagged(t *testing.T) {
 	var buf bytes.Buffer
 
 	result := types.MoveResult{
+		Matched:   1,
+		Processed: 1,
+		Failed:    0,
 		Unflagged: []string{"M3"},
 		Errors:    []string{},
 	}
@@ -553,8 +559,60 @@ func TestTextFormatter_MoveResultUnflagged(t *testing.T) {
 	}
 
 	out := buf.String()
-	if !strings.Contains(out, "Unflagged: M3") {
-		t.Errorf("expected unflagged IDs, got: %s", out)
+	if !strings.Contains(out, "Unflagged 1 of 1 matched emails (0 failed)") {
+		t.Errorf("expected compact summary, got: %s", out)
+	}
+}
+
+func TestTextFormatter_MoveResultAllFailed(t *testing.T) {
+	f := &TextFormatter{}
+	var buf bytes.Buffer
+
+	result := types.MoveResult{
+		Matched:   2,
+		Processed: 2,
+		Failed:    2,
+		Errors:    []string{"M1: server error", "M2: server error"},
+	}
+
+	if err := f.Format(&buf, result); err != nil {
+		t.Fatal(err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Processed 0 of 2 matched emails (2 failed)") {
+		t.Errorf("expected fallback summary, got: %s", out)
+	}
+	if !strings.Contains(out, "M1: server error") {
+		t.Errorf("expected error detail, got: %s", out)
+	}
+}
+
+func TestTextFormatter_MoveResultMovedWithDestination(t *testing.T) {
+	f := &TextFormatter{}
+	var buf bytes.Buffer
+
+	result := types.MoveResult{
+		Matched:   3,
+		Processed: 3,
+		Failed:    0,
+		Moved:     []string{"M1", "M2", "M3"},
+		Destination: &types.DestinationInfo{
+			ID: "mb-receipts", Name: "Receipts",
+		},
+		Errors: []string{},
+	}
+
+	if err := f.Format(&buf, result); err != nil {
+		t.Fatal(err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Moved 3 of 3 matched emails to Receipts (0 failed)") {
+		t.Errorf("expected compact summary with destination, got: %s", out)
+	}
+	if strings.Contains(out, "M1") || strings.Contains(out, "M2") || strings.Contains(out, "M3") {
+		t.Errorf("should not list individual IDs, got: %s", out)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Replace verbose ID-listing text output for action commands with a compact one-line summary (e.g., `Archived 527 of 527 matched emails (0 failed)`)
- JSON output is unchanged, preserving full ID lists for programmatic use
- Move command includes destination in summary (e.g., `Moved 5 of 5 matched emails to Receipts (0 failed)`)
- Add edge-case tests for all-failed and move-with-destination scenarios

## Test plan

- [ ] `go test ./...` passes (8 MoveResult text formatter tests, including 2 new)
- [ ] `go vet ./...` reports no issues
- [ ] `golangci-lint run ./...` reports no issues
- [ ] `make test-cli` passes all scrut tests
- [ ] Manual: `fm archive --from <sender> --format text` produces compact one-line output
- [ ] Manual: `fm archive --from <sender> --format json` still includes full ID list

## Closes

Closes #71
