### PR TITLE
chore: pin gh-actions to v2.1.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   ci:
-    uses: cboone/gh-actions/.github/workflows/go-ci.yml@v2
+    uses: cboone/gh-actions/.github/workflows/go-ci.yml@v2.1.2
     with:
       run-scrut: true
       scrut-build-cmd: "go build ."

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -9,6 +9,6 @@ on:
 
 jobs:
   gitleaks:
-    uses: cboone/gh-actions/.github/workflows/secret-scan.yml@v1
+    uses: cboone/gh-actions/.github/workflows/secret-scan.yml@v2.1.2
     with:
       tool: gitleaks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,6 @@ permissions:
 
 jobs:
   release:
-    uses: cboone/gh-actions/.github/workflows/go-release.yml@v1
+    uses: cboone/gh-actions/.github/workflows/go-release.yml@v2.1.2
     secrets:
       HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}


### PR DESCRIPTION
Pin all `cboone/gh-actions` workflow and action references from floating
tags (`@v1`, `@v2`) to the exact version `@v2.1.2`.

Part of the migration to exact-version-only tagging (cboone/gh-actions#25).
After all consuming repos are updated, the floating `v1` and `v2` tags
will be deleted from the gh-actions remote.